### PR TITLE
feat: add /cat command

### DIFF
--- a/.changes/feat-add-cat-command.md
+++ b/.changes/feat-add-cat-command.md
@@ -1,0 +1,4 @@
+---
+workshop-bot: patch
+---
+Add a /cat command that sends a random kitty review gif

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "anyhow",
  "basic-toml",
  "i18n",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ tracing-subscriber = "0.3.16"
 serde = { version = "1.0.152", features = [ "derive" ] }
 basic-toml = { version = "0.1.1" }
 serde_json = "1.0.91"
+rand = "0.8.5"

--- a/Config.example.toml
+++ b/Config.example.toml
@@ -3,9 +3,8 @@
 # A discord token for the bot to login
 discord_token = 'Your token'
 
-# An API key for the Tenor API for commands like /cat, leave empty if you do not want such commands
-# Uncomment if you want to enable these commands (but provide an API key too)
-#tenor_api_key = 'Your Tenor API key'
+# An API key for the Tenor API for commands like /cat, comment it out if you do not want such commands
+tenor_api_key = 'Your Tenor API key'
 
 # Where the invite should be created (run when app gets created and is logged with the INFO level)
 workshop_invite_channel = 877

--- a/Config.example.toml
+++ b/Config.example.toml
@@ -3,6 +3,10 @@
 # A discord token for the bot to login
 discord_token = 'Your token'
 
+# An API key for the Tenor API for commands like /cat, leave empty if you do not want such commands
+# Uncomment if you want to enable these commands (but provide an API key too)
+#tenor_api_key = 'Your Tenor API key'
+
 # Where the invite should be created (run when app gets created and is logged with the INFO level)
 workshop_invite_channel = 877
 

--- a/Config.example.toml
+++ b/Config.example.toml
@@ -4,7 +4,7 @@
 discord_token = 'Your token'
 
 # An API key for the Tenor API for commands like /cat, comment it out if you do not want such commands
-tenor_api_key = 'Your Tenor API key'
+tenor_token = 'Your Tenor API key'
 
 # Where the invite should be created (run when app gets created and is logged with the INFO level)
 workshop_invite_channel = 877

--- a/locale/cs.json
+++ b/locale/cs.json
@@ -30,6 +30,9 @@
     "skull": {
       "description": "Pošle skull gif",
       "message": ":skull:"
+    },
+    "cat": {
+      "description": "Pošle kitty review gif"
     }
   },
   "modules": {

--- a/locale/en.json
+++ b/locale/en.json
@@ -30,6 +30,9 @@
     "skull": {
       "description": "Sends a skull gif",
       "message": ":skull:"
+    },
+    "cat": {
+      "description": "Sends a kitty review gif"
     }
   },
   "modules": {

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -56,7 +56,7 @@ async fn get_link(ctx: &Context) -> Result<String> {
     let json = data.json::<TenorAPIResponse>().await?;
 
     match json.results.choose(&mut rand::thread_rng()) {
-        Some(result) => Ok(result.media_formats.gif.url.clone()),
+        Some(result) => Ok(result.media_formats.gif.url.to_owned()),
         None => Err(anyhow!("No GIFs found"))
     }
 }

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -1,0 +1,71 @@
+use serenity::builder::CreateApplicationCommand;
+use serenity::model::prelude::interaction::application_command::ApplicationCommandInteraction;
+use serenity::model::prelude::interaction::InteractionResponseType;
+use serenity::prelude::Context;
+use serenity::utils::Color;
+use tracing::error;
+use rand::seq::SliceRandom;
+use i18n::t;
+
+pub(crate) fn register(
+    command: &mut CreateApplicationCommand,
+) -> &mut CreateApplicationCommand {
+    command
+        .name("cat")
+        .description(t!("commands.cat.description").to_string())
+        .description_localized("cs", t!("commands.cat.description", "cs"))
+        .dm_permission(true)
+}
+
+//TODO: no hardcoding keys
+async fn get_link() -> anyhow::Result<String> {
+    let api_key = "AIzaSyBYTniO_HQAop9AAAE5fo7KAPcqq_wIlv4";
+    let term = "kitty%20review";
+    let url = format!("https://tenor.googleapis.com/v2/search?q={}&key={}&limit=50", term, api_key);
+
+    let response = reqwest::get(url).await;
+    if let Ok(response) = response {
+        let json = response.json::<serde_json::Value>().await;
+        if let Ok(json) = json {
+            if let Some(results) = json.get("results").and_then(|results| results.as_array()) {
+                if let Some(random_result) = results.choose(&mut rand::thread_rng()) {
+                    if let Some(gif) = random_result["media_formats"]["gif"]["url"].as_str() {
+                        return Ok(gif.to_string());
+                    }
+                }
+            }
+        }
+    }
+    //Why can't I just return a string literal in Ok()?
+    let error = "";
+    Ok(error.to_string())
+}
+
+pub(crate) async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
+    let result = match get_link().await {
+        Ok(url) => url,
+        Err(e) => {
+            error!("Error while running cat command: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = command
+        .create_interaction_response(&ctx.http, |response| {
+            response
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(|message| {
+                    message
+                        .embed(|embed| embed
+                            .image(result)
+                            .color(Color::from_rgb(110, 110, 110)))
+                })
+        })
+        .await
+    {
+        error!(
+            "There was an error while responding to cat command: {}",
+            e
+        )
+    };
+}

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -57,7 +57,7 @@ async fn get_link(ctx: &Context) -> Result<String> {
 
     match json.results.choose(&mut rand::thread_rng()) {
         Some(result) => Ok(result.media_formats.gif.url.clone()),
-        None => Err(anyhow!("No GIFs found")),
+        None => Err(anyhow!("No GIFs found"))
     }
 }
 

--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -41,7 +41,10 @@ struct TenorAPIResponse {
 }
 
 async fn get_link(ctx: &Context) -> Result<String> {
-    let api_key = get_state(ctx).await.config.tenor_api_key.expect("Missing tenor_api_key in the config");
+    let api_key = match get_state(ctx).await.config.tenor_api_key {
+        Some(api_key) => api_key,
+        None => return Err(anyhow!("Missing Tenor API key"))
+    };
     let term = "kitty%20review";
     let url = format!("https://tenor.googleapis.com/v2/search?q={term}&key={api_key}&limit=100");
 
@@ -75,7 +78,7 @@ pub(crate) async fn run(ctx: &Context, command: &ApplicationCommandInteraction) 
             response
                 .kind(InteractionResponseType::ChannelMessageWithSource)
                 .interaction_response_data(|message| {
-                    message.embed(|embed| embed.image(result).color(Color::from_rgb(110, 110, 110)))
+                    message.embed(|embed| embed.image(result).color(Color::from_rgb(227, 0, 0)))
                 })
         })
         .await

--- a/src/commands/chad.rs
+++ b/src/commands/chad.rs
@@ -24,7 +24,6 @@ fn get_message(locale: String) -> &'static str {
 }
 
 pub(crate) async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
-    println!("running chad cmd");
     let locale = command.clone().locale;
 
     if let Err(e) = command

--- a/src/commands/chad.rs
+++ b/src/commands/chad.rs
@@ -24,6 +24,7 @@ fn get_message(locale: String) -> &'static str {
 }
 
 pub(crate) async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
+    println!("running chad cmd");
     let locale = command.clone().locale;
 
     if let Err(e) = command

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -76,13 +76,13 @@ pub(crate) async fn register_commands(ctx: &Context) {
     );
 
     if get_state(ctx).await.config.tenor_api_key.clone().is_some() {
-        //Register commands that use the Tenor API here!
+        //Register commands that use the Tenor API here.
         results.push(
             Command::create_global_application_command(&ctx.http, |command| {cat::register(command)})
                 .await,
         );
     } else {
-        warn!("Warning: missing tenor_api_key, commands like cat that use the Tenor API won't work!");
+        warn!("Missing tenor_api_key, commands like cat that use the Tenor API won't work!");
     }
 
     match results

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,14 +3,15 @@ use serenity::model::application::command::Command;
 use serenity::model::prelude::GuildId;
 use tracing::{error, info};
 
+pub(crate) mod chad;
 pub(crate) mod otakugif;
 pub(crate) mod reaction_role;
-pub(crate) mod workshop;
-pub(crate) mod chad;
 pub(crate) mod skull;
+pub(crate) mod workshop;
+pub(crate) mod cat;
 
 pub(crate) async fn register_commands(ctx: &Context) {
-    let guild_id = GuildId::from(1069606131510562889);
+    let guild_id = GuildId::from(1075100339918876692);
 
     info!(
         "{:?}",
@@ -63,18 +64,19 @@ pub(crate) async fn register_commands(ctx: &Context) {
     );
 
     results.push(
-        Command::create_global_application_command(&ctx.http, |command| {
-            chad::register(command)
-        })
+        Command::create_global_application_command(&ctx.http, |command| {chad::register(command)})
+        .await,
+    );
+
+    results.push(
+        Command::create_global_application_command(&ctx.http, |command| {skull::register(command)})
             .await,
     );
 
-     results.push(
-            Command::create_global_application_command(&ctx.http, |command| {
-                skull::register(command)
-            })
-                .await,
-        );
+    results.push(
+        Command::create_global_application_command(&ctx.http, |command| {cat::register(command)})
+            .await,
+    );
 
     match results
         .into_iter()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,7 +1,7 @@
 use serenity::client::Context;
 use serenity::model::application::command::Command;
 use serenity::model::prelude::GuildId;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::state::get_state;
 
@@ -76,12 +76,13 @@ pub(crate) async fn register_commands(ctx: &Context) {
     );
 
     if get_state(ctx).await.config.tenor_api_key.clone().is_some() {
+        //Register commands that use the Tenor API here!
         results.push(
             Command::create_global_application_command(&ctx.http, |command| {cat::register(command)})
                 .await,
         );
     } else {
-        error!("Warning: missing tenor_api_key, commands like cat that use the Tenor API won't work!");
+        warn!("Warning: missing tenor_api_key, commands like cat that use the Tenor API won't work!");
     }
 
     match results

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod workshop;
 pub(crate) mod cat;
 
 pub(crate) async fn register_commands(ctx: &Context) {
-    let guild_id = GuildId::from(1075100339918876692);
+    let guild_id = GuildId::from(1069606131510562889);
 
     info!(
         "{:?}",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,8 @@ use serenity::model::application::command::Command;
 use serenity::model::prelude::GuildId;
 use tracing::{error, info};
 
+use crate::state::get_state;
+
 pub(crate) mod chad;
 pub(crate) mod otakugif;
 pub(crate) mod reaction_role;
@@ -73,10 +75,14 @@ pub(crate) async fn register_commands(ctx: &Context) {
             .await,
     );
 
-    results.push(
-        Command::create_global_application_command(&ctx.http, |command| {cat::register(command)})
-            .await,
-    );
+    if get_state(ctx).await.config.tenor_api_key.clone().is_some() {
+        results.push(
+            Command::create_global_application_command(&ctx.http, |command| {cat::register(command)})
+                .await,
+        );
+    } else {
+        error!("Warning: missing tenor_api_key, commands like cat that use the Tenor API won't work!");
+    }
 
     match results
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ impl EventHandler for Bot {
                 "slap" => commands::otakugif::run(&ctx, &command, "slap").await,
                 "chad" => commands::chad::run(&ctx, &command).await,
                 "skull" => commands::skull::run(&ctx, &command).await,
+                "cat" => commands::cat::run(&ctx, &command).await,
                 name => warn!("Received a command which is not implemented: {}", name),
             },
             Interaction::MessageComponent(component) => match component.data.custom_id.as_str() {

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct BotConfig {
     #[serde(alias = "discord_token")]
     pub token: Option<String>,
+    pub tenor_api_key: Option<String>,
     #[serde(rename = "workshop_invite_channel")]
     pub invite_channel: Option<u64>,
     pub guilds: HashMap<String, GuildConfig>

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct BotConfig {
     #[serde(alias = "discord_token")]
     pub token: Option<String>,
+    #[serde(alias = "tenor_token")]
     pub tenor_api_key: Option<String>,
     #[serde(rename = "workshop_invite_channel")]
     pub invite_channel: Option<u64>,


### PR DESCRIPTION
This pull request uses the Tenor API to fetch kitty review gifs from Tenor and post them in the Discord channel. There is a similar PR, but it uses a static list of gifs. This can be easily modified to search for any other term. The Tenor API key is stored in an environment variable (TENOR_API_KEY), because I couldn't figure out how to properly pass on the config struct to the command. This uses serde structs to deserialize the JSON data.

It has been tested on my own server, and it works fine.
If you don't want to bother with creating an API key, you can message me directly, though mine is compromised because I totally didn't include it in a commit on accident... (Edit: I'll regenerate it [Edit2: done])