### PR TITLE
fix: attribution to Tenor GIFs

### DIFF
--- a/src/commands/cat.rs
+++ b/src/commands/cat.rs
@@ -78,7 +78,11 @@ pub(crate) async fn run(ctx: &Context, command: &ApplicationCommandInteraction) 
             response
                 .kind(InteractionResponseType::ChannelMessageWithSource)
                 .interaction_response_data(|message| {
-                    message.embed(|embed| embed.image(result).color(Color::from_rgb(227, 0, 0)))
+                    message.embed(|embed| embed
+                        .image(result)
+                        .color(Color::from_rgb(227, 0, 0))
+                        .footer(|f| f.text("Via Tenor"))
+                    )
                 })
         })
         .await


### PR DESCRIPTION
This patch adds a "Via Tenor" footer to GIFs sent by commands that use the Tenor API. The previous PR was closed because there were 14 commits when only 1 file change was really necessary.